### PR TITLE
Make tests configurable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,5 +22,5 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
-config :docker_api, :hosts,
-  ["docker0001.wameku.com:14443", "192.168.4.4:14443"]
+
+import_config "#{Mix.env}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,4 +23,7 @@ use Mix.Config
 #
 #     import_config "#{Mix.env}.exs"
 
+config :hackney, :max_connections, 10
+config :hackney, :timeout, 5_000
+
 import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,2 +1,3 @@
 use Mix.Config
-config :docker_api, :host, "127.0.0.1:2376"
+config :docker_api, :host, System.get_env("DOCKER_API_HOST") || "127.0.0.1"
+config :docker_api, :port, System.get_env("DOCKER_API_PORT") || "2376"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,2 @@
+use Mix.Config
+config :docker_api, :host, "127.0.0.1:2376"

--- a/test/containers_test.exs
+++ b/test/containers_test.exs
@@ -1,7 +1,7 @@
 defmodule DockerApiContainerTest do
   use ExUnit.Case
 
-  @host "192.168.4.4:14443"
+  @host Application.get_env(:docker_api, :host)
   @cid "86fda78c440e"
 
   test "/containers" do

--- a/test/containers_test.exs
+++ b/test/containers_test.exs
@@ -1,7 +1,7 @@
 defmodule DockerApiContainerTest do
   use ExUnit.Case
 
-  @host Application.get_env(:docker_api, :host)
+  @host "#{Application.get_env(:docker_api, :host)}:#{Application.get_env(:docker_api, :port)}"
   @cid "86fda78c440e"
 
   test "/containers" do

--- a/test/events_test.exs
+++ b/test/events_test.exs
@@ -3,7 +3,7 @@ defmodule DockerApiEventsTest do
 
   import Mock
 
-  @host Application.get_env(:docker_api, :host)
+  @host "#{Application.get_env(:docker_api, :host)}:#{Application.get_env(:docker_api, :port)}"
 
   test "/events" do
     with_mock DockerApi.Events, [all: fn(_host) -> {:ok, []} end] do

--- a/test/events_test.exs
+++ b/test/events_test.exs
@@ -3,7 +3,7 @@ defmodule DockerApiEventsTest do
 
   import Mock
 
-  @host "192.168.4.4:14443"
+  @host Application.get_env(:docker_api, :host)
 
   test "/events" do
     with_mock DockerApi.Events, [all: fn(_host) -> {:ok, []} end] do

--- a/test/http.exs
+++ b/test/http.exs
@@ -1,7 +1,7 @@
 defmodule DockerApiHTTPTest do
   use ExUnit.Case
 
-  @host "192.168.4.4:14443"
+  @host Application.get_env(:docker_api, :host)
   @cid "971f52624eb3"
 
   test "get" do

--- a/test/http.exs
+++ b/test/http.exs
@@ -1,7 +1,7 @@
 defmodule DockerApiHTTPTest do
   use ExUnit.Case
 
-  @host Application.get_env(:docker_api, :host)
+  @host "#{Application.get_env(:docker_api, :host)}:#{Application.get_env(:docker_api, :port)}"
   @cid "971f52624eb3"
 
   test "get" do

--- a/test/images_test.exs
+++ b/test/images_test.exs
@@ -2,7 +2,7 @@ defmodule DockerApiImageTest do
   use ExUnit.Case
   import PathHelpers
 
-  @host "192.168.4.4:14443"
+  @host Application.get_env(:docker_api, :host)
   @iid "868be653dea3"
 
   test "/images" do

--- a/test/images_test.exs
+++ b/test/images_test.exs
@@ -2,7 +2,7 @@ defmodule DockerApiImageTest do
   use ExUnit.Case
   import PathHelpers
 
-  @host Application.get_env(:docker_api, :host)
+  @host "#{Application.get_env(:docker_api, :host)}:#{Application.get_env(:docker_api, :port)}"
   @iid "868be653dea3"
 
   test "/images" do


### PR DESCRIPTION
The existing test configurations are specific to a certain environment and not very configurable.

This makes the test configuration (i.e. where to find docker) more generic (localhost) and configurable.
